### PR TITLE
Fixed log rotation bug

### DIFF
--- a/etc/logrotate.d/cowrie
+++ b/etc/logrotate.d/cowrie
@@ -1,4 +1,4 @@
-/srv/cowrie/log/cowrie.*
+/srv/cowrie/log/cowrie.log /srv/cowrie/log/cowrie.json
 {
 	rotate 7
 	daily


### PR DESCRIPTION
Hi Johannes,

By using cowrie.*, you will generate unlimited files while performing the rotation:

-rw-r--r-- 1 cowrie cowrie    3645 Mar 11 09:04 cowrie.json
-rw-r--r-- 1 cowrie cowrie   17748 Mar 11 06:24 cowrie.json.1.gz
-rw-r--r-- 1 cowrie cowrie       0 Mar 10 06:25 cowrie.json.1.gz.1.gz
-rw-r--r-- 1 cowrie cowrie       0 Mar 10 06:25 cowrie.json.1.gz.1.gz.1.gz
-rw-r--r-- 1 cowrie cowrie   23436 Mar  9 06:25 cowrie.json.1.gz.1.gz.1.gz.1.gz
-rw-r--r-- 1 cowrie cowrie   30956 Mar  7 06:25 cowrie.json.1.gz.1.gz.1.gz.2.gz
-rw-r--r-- 1 cowrie cowrie       0 Mar 10 06:26 cowrie.json.1.gz.1.gz.2.gz
-rw-r--r-- 1 cowrie cowrie      20 Mar  7 06:25 cowrie.json.1.gz.1.gz.2.gz.1.gz
-rw------- 1 cowrie cowrie   13470 Mar  7 06:25 cowrie.json.1.gz.1.gz.3.gz
-rw------- 1 cowrie cowrie   11051 Mar  5 06:25 cowrie.json.1.gz.1.gz.4.gz
etc...