### PR TITLE
urlencode '+' characters in email addresses

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -750,9 +750,10 @@ if [ $return_value -eq  $DIALOG_OK ]; then
                dlog "Calculating hash."
 	       hash=`echo -n $email:$apikey | openssl dgst -hmac $nonce -sha512 -hex | cut -f2 -d'=' | tr -d ' '`
                dlog "Calculated nonce (${nonce}) and hash (${hash})."
-   
-	       user=`echo $email | sed 's/@/%40/'`
-               dlog "Checking API key ...."
+
+	       # TODO: urlencode($user)
+	       user=`echo $email | sed 's/+/%2b/' | sed 's/@/%40/'`
+               dlog "Checking API key ..."
 	       run 'curl -s https://isc.sans.edu/api/checkapikey/$user/$nonce/$hash > $TMPDIR/checkapi'
    
                dlog "Curl return code is ${?}"

--- a/bin/status.sh
+++ b/bin/status.sh
@@ -26,7 +26,8 @@ fi
 
 nonce=`openssl rand -hex 10`
 hash=`echo -n $email:$apikey | openssl dgst -hmac $nonce -sha512 -hex | cut -f2 -d'=' | tr -d ' '`
-user=`echo $email | sed 's/@/%40/'`
+# TODO: urlencode($user)
+user=`echo $email | sed 's/+/%2b/' | sed 's/@/%40/'`
 status=`curl -s https://isc.sans.edu/api/checkapikey/$user/$nonce/$hash`
 if [ "$status" = "" ] ; then
    echo "Error connecting to DShield. Try again in 5 minutes. For details, run:"

--- a/etc/cron.hourly/dshield
+++ b/etc/cron.hourly/dshield
@@ -22,7 +22,8 @@ version=0.0
 . /etc/dshield.conf
 nonce=`openssl rand -hex 10`
 hash=`echo -n $email:$apikey | openssl dgst -hmac $nonce -sha512 -hex | cut -f2 -d'=' | tr -d ' '`
-user=`echo $email | sed 's/@/%40/'`
+# TODO: urlencode($user)
+user=`echo $email | sed 's/+/%2b/' | sed 's/@/%40/'`
 newversion=`wget -q -O - https://isc.sans.edu/api/checkapikey/$user/$nonce/$hash | grep '<result>ok</result>' | grep '\<version\>' | sed 's/.*<version>//' | sed 's/<\/version>.*//'`
 majornewversion=`echo $newversion | cut -f1 -d'.'`
 majoroldversion=`echo $version | cut -f1 -d'.'`


### PR DESCRIPTION
My email address contains a perfectly valid `+` character, but I wasn’t being allowed to login to the DShield client. This patch fixes it so that at least I can login.

(Please note that the mailbox part of an email address even can contain an `@` symbol and be a valid email address — and then we have all the international characters and issues therein too.)

TOOD: actually urlencode all the things properly.