### PR TITLE
New type - webhoneypot

### DIFF
--- a/srv/dshield/DShield.py
+++ b/srv/dshield/DShield.py
@@ -52,7 +52,7 @@ class DshieldSubmit:
     id = 0
     key = ''
     url = 'https://www.dshield.org/submitapi/'
-    types = ['email', 'firewall', 'sshlogin', 'telnetlogin', '404report', 'httprequest']
+    types = ['email', 'firewall', 'sshlogin', 'telnetlogin', '404report', 'httprequest', 'webhoneypot']
     authheader = ''
 
     def __init__(self, filename):

--- a/srv/dshield/weblogsubmit.py
+++ b/srv/dshield/weblogsubmit.py
@@ -8,6 +8,18 @@ from DShield import DshieldSubmit
 from datetime import datetime
 import json
 
+# We need to collect the local IP to scrub it from any logs being submitted for anonymity, and to reduce noise/dirty data.
+# To do: turn below into a function and add __name__ to this script so that if we need to import parsing dshield.conf elsewhere, can be done easily.
+# Should also define DSHIELD_CONF as a variable, to allow for flexibility of location.
+iface = ''
+with open('/etc/dshield.conf') as conf:
+    data = conf.readlines()
+    for line in data:
+        if 'interface' in line:
+            iface = line.split('=')[1].replace("\n", "")
+
+ipaddr = os.popen('ifconfig ' + iface + ' | grep "inet\ addr" | cut -d: -f2 | cut -d" " -f1').read().replace("\n", "")
+
 pidfile = "/var/run/weblogparser.pid"
 if os.path.isfile(pidfile):
     sys.exit('PID file found. Am I already running?')
@@ -34,26 +46,30 @@ except sqlite3.Error, e:
     os.remove(pidfile)
     sys.exit(1)
 
-    
 starttime=0
 
 if str(maxid[0]) != "None" :
     starttime=float(maxid[0])
-rsx=c.execute("""SELECT date, address, cmd, path, useragent,targetip from requests where date>?""",[starttime]).fetchall()
+rsx=c.execute("""SELECT date, headers, address, cmd, path, useragent,targetip from requests where date>?""",[starttime]).fetchall()
 logs = []
 logdata = {}
 lasttime = starttime
 linecount = 0
 for r in rsx:
-     logdata['time']=float(r[0])
-     logdata['sip']=r[1]
-     logdata['dip']=r[5]
-     logdata['method']=str(r[2])
-     logdata['url']=str(r[3])
-     logdata['useragent']=str(r[4])
-     lasttime = int(float(r[0]))+1
-     linecount = linecount+1
-     logs.append(logdata)
+    headerdata = {}
+    logdata['time']=float(r[0])
+    for each in r[1].split('\r\n'): # Header data was stored as a string with extra characters, so some clean-up needed.
+        if (each and ipaddr not in each): # scrubbing local IP from data before submission
+            headerdata['header_'+str(each.split(': ')[0])] = each.split(': ')[1]
+    logdata['headers']=headerdata # Adding header data as a sub-dictionary
+    logdata['sip']=r[2]
+    logdata['dip']=r[6]
+    logdata['method']=str(r[3])
+    logdata['url']=str(r[4])
+    logdata['useragent']=str(r[5])
+    lasttime = int(float(r[0]))+1
+    linecount = linecount+1
+    logs.append(logdata)
 if starttime == lasttime:
     conn.close()
     os.remove(pidfile)
@@ -67,11 +83,11 @@ except sqlite3.Error, e:
     os.remove(pidfile)
     sys.exit(1)
 
-l = {'type': '404report', 'logs': logs}
+l = {'type': 'web_honeypot', 'logs': logs} # Changed type from 404report to reflect addition of new header data
 d.post(l)
 os.remove(pidfile)
 
 try:
-    os.popen("systemctl restart webpy")
+    os.popen("systemctl restart webpy")  # Web.py seems to hang periodically, so to bandaid this situation, we restart web.py twice an hour
 except:
     pass

--- a/srv/dshield/weblogsubmit.py
+++ b/srv/dshield/weblogsubmit.py
@@ -83,7 +83,7 @@ except sqlite3.Error, e:
     os.remove(pidfile)
     sys.exit(1)
 
-l = {'type': 'web_honeypot', 'logs': logs} # Changed type from 404report to reflect addition of new header data
+l = {'type': 'webhoneypot', 'logs': logs} # Changed type from 404report to reflect addition of new header data
 d.post(l)
 os.remove(pidfile)
 

--- a/srv/www/bin/db_builder.py
+++ b/srv/www/bin/db_builder.py
@@ -142,6 +142,7 @@ def build_DB():
     c.execute('''CREATE TABLE IF NOT EXISTS requests
                 (
                     date text,
+                    headers text,
                     address text,
                     cmd text,
                     path text,

--- a/srv/www/bin/web.py
+++ b/srv/www/bin/web.py
@@ -89,10 +89,14 @@ class MyHandler(BaseHTTPRequestHandler):
                 site = i
                 file_path = os.path.join(webpath, i)
         dte = time.time()
-        cladd = self.client_address[0]
         targetip = '0.0.0.0'
+        # Each self.<module> item specified here as a variable needs to be specified in db_builder.py as well so that the db has a column to store it.
+        cladd = self.client_address[0]
         cmd = '%s' % self.command  # same as ubelow
         path = '%s' % self.path  # see below comment
+        headers = '%s' % self.headers
+        # content_len = int(self.headers.getheader('content-length', 0))
+        # body = self.rfile.read(content_len)
 
         try:
             if str(self.headers['user-agent']) is not None:
@@ -100,9 +104,9 @@ class MyHandler(BaseHTTPRequestHandler):
         except:
             useragentstring = ""
         #self.send_response(200)
-        rvers=''
-        c.execute("""INSERT INTO requests (date, address, cmd, path, useragent, vers, summary,targetip) VALUES(?, ?, ?, ?, ?, ?, ?,?)""",
-                  (dte, cladd, cmd, path, useragentstring, rvers, '- Standard Request.',targetip))
+        rvers = '%s' % self.request_version
+        c.execute("""INSERT INTO requests (date, headers, address, cmd, path, useragent, vers, summary,targetip) VALUES(?, ?, ?, ?, ?, ?, ?, ?,?)""",
+                  (dte, headers, cladd, cmd, path, useragentstring, rvers, '- Standard Request.',targetip))
         try:
             c.execute("""INSERT INTO useragents (useragent) VALUES (?)""", [useragentstring])
         except sqlite3.IntegrityError:
@@ -206,6 +210,7 @@ class MyHandler(BaseHTTPRequestHandler):
         cladd = '%s' % self.client_address[0]
         cmd = '%s' % self.command
         path = '%s' % self.path
+
         try:
             if str(self.headers['user-agent']) is not None:
                 useragentstring = str(self.headers['user-agent'])


### PR DESCRIPTION
Added full headers collected from web.py. The webserver.sqlite db needs a new column, so will need to be rebuilt. I have not provided an automated way to do this (I just renamed the file on my Pi). The new column is called 'headers' and is populated with the headers section of the BaseHTTPRequestHandler used in web.py. 

In testing, I saw that it is possible to specify an element in the header but have the actual browser include it's own header. In this way, you can end up with two different user agents for example. Therefore the new 'headers' column can have some duplicate fields (e.g. user agent) which was already collected as part of the 404report, in case the fields are the same but the data is different. 

With these changes, weblogsubmit now sends a new type 'webhoneypot' which supplants the old '404report'. 

Files altered: DShield.py, db_builder.py, web.py, weblogsubmit.py. 