### PR TITLE
Update dshield.conf to eliminate duplicate logging

### DIFF
--- a/etc/rsyslog.d/dshield.conf
+++ b/etc/rsyslog.d/dshield.conf
@@ -1,2 +1,3 @@
 $template DShieldTemplate,"%timegenerated:::date-unixtimestamp% %HOSTNAME% %syslogtag%%msg%\n"
 if $msg contains " DSHIELDINPUT " then /var/log/dshield.log;DShieldTemplate
+& stop


### PR DESCRIPTION
Current config sends output to /var/log/dshield.log, /var/log/kern/log, /var/log/messages and /var/log/syslog
Updated to only send to /var/log/dshield.log