### PR TITLE
Added "enabled = true" to [output_dshield] section appended to cowrie.cfg

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1542,6 +1542,7 @@ dlog "copying cowrie.cfg and adding entries"
 do_copy /srv/cowrie/cowrie.cfg.dist /srv/cowrie/cowrie.cfg 644
 cat >> /srv/cowrie/cowrie.cfg <<EOF
 [output_dshield]
+enabled = true
 userid = $uid
 auth_key = $apikey
 batch_size = 1


### PR DESCRIPTION
The install.sh file appends an [output_dshield] section to the /srv/cowrie/cowrie.cfg file. Adding "enabled = true" to that section allows the cowrie service to start, listen on ports 2222 (SSH) and 2223 (Telnet), and submit data to the DShield server.

Without "enabled = true" a clean installation has the following cowrie errors in /var/log/syslog:

```
May  4 22:54:45 raspberrypi cowrie[202]: Starting Cowrie Honeypot:Using default Python virtual environment "/srv/cowrie/cowrie-env"
May  4 22:54:45 raspberrypi cowrie[202]: Starting cowrie: [twistd   --umask 0022 --pidfile var/run/cowrie.pid --logger cowrie.python.logfile.logger cowrie ]...
May  4 22:56:11 raspberrypi cowrie[202]: Traceback (most recent call last):
May  4 22:56:11 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/bin/twistd", line 11, in <module>
May  4 22:56:11 raspberrypi cowrie[202]:     sys.exit(run())
May  4 22:56:11 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/twisted/scripts/twistd.py", line 31, in run
May  4 22:56:11 raspberrypi cowrie[202]:     app.run(runApp, ServerOptions)
May  4 22:56:11 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/twisted/application/app.py", line 674, in run
May  4 22:56:11 raspberrypi cowrie[202]:     runApp(config)
May  4 22:56:11 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/twisted/scripts/twistd.py", line 25, in runApp
May  4 22:56:11 raspberrypi cowrie[202]:     runner.run()
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/twisted/application/app.py", line 381, in run
May  4 22:56:12 raspberrypi cowrie[202]:     self.application = self.createOrGetApplication()
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/twisted/application/app.py", line 448, in createOrGetApplication
May  4 22:56:12 raspberrypi cowrie[202]:     ser = plg.makeService(self.config.subOptions)
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/twisted/plugins/cowrie_plugin.py", line 159, in makeService
May  4 22:56:12 raspberrypi cowrie[202]:     if CONFIG.getboolean(x, 'enabled') is False:
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/backports/configparser/__init__.py", line 849, in getboolean
May  4 22:56:12 raspberrypi cowrie[202]:     **kwargs)
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/backports/configparser/__init__.py", line 822, in _get_conv
May  4 22:56:12 raspberrypi cowrie[202]:     return self._get(section, conv, option, **kwargs)
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/backports/configparser/__init__.py", line 814, in _get
May  4 22:56:12 raspberrypi cowrie[202]:     return conv(self.get(section, option, **kwargs))
May  4 22:56:12 raspberrypi cowrie[202]:   File "/srv/cowrie/cowrie-env/local/lib/python2.7/site-packages/backports/configparser/__init__.py", line 803, in get
May  4 22:56:12 raspberrypi cowrie[202]:     raise NoOptionError(option, section)
May  4 22:56:12 raspberrypi cowrie[202]: backports.configparser.NoOptionError: No option 'enabled' in section: u'output_dshield'
May  4 22:56:13 raspberrypi cowrie[202]:  failed!
```
