### PR TITLE
Fix auth header submit with extra serialized chars

### DIFF
--- a/srv/dshield/DShield.py
+++ b/srv/dshield/DShield.py
@@ -79,9 +79,9 @@ class DshieldSubmit:
         return r.json()['ip']
 
     def makeauthheader(self):
-        nonce = base64.b64encode(os.urandom(8))
-        myhash = hmac.new((str(nonce)+str(self.id)).encode('utf-8'), msg=self.key.encode('utf-8'), digestmod=hashlib.sha256).digest()
-        hash64 = base64.b64encode(myhash)
+        nonce = base64.b64encode(os.urandom(8)).decode()
+        myhash = hmac.new((nonce + str(self.id)).encode('utf-8'), msg=self.key.encode('utf-8'), digestmod=hashlib.sha256).digest()
+        hash64 = base64.b64encode(myhash).decode()
         header = 'ISC-HMAC-SHA256 Credentials=%s Userid=%s Nonce=%s' % (hash64, self.id, nonce.rstrip())
         return header
 


### PR DESCRIPTION
Fixes an issue where submissions auth header contains extra characters in authkey and nonce members. submissions are currently serializing a byte string which prevents keys from being authorized. i.e. `"b'0T9zyG7u5RvyfKTD5afeh5vK1TUkCuDVPdQpKphLOjc='=\", \"nonce\": \"b'7panZz3BuLY='\"`