### PR TITLE
Using wait-online.service to wait for networking

### DIFF
--- a/lib/systemd/system/webpy.service
+++ b/lib/systemd/system/webpy.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=DShield Web Honeypot
-After=multi-user.target
+After=systemd-networkd-wait-online.service
+Wants=systemd-networkd-wait-online.service
 
 [Service]
 Type=idle


### PR DESCRIPTION
Using systemd-networkd-wait-online.service enabled during installation to wait for network connection and avoid webpy service from failing upon reboot

depends on patch-4 https://github.com/DShield-ISC/dshield/pull/137/commits/e84e9d91b7e67689f9365e7ca5fa0073374cbf6f