### PR TITLE
enable networkd service and networkd-wait-online

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1523,6 +1523,7 @@ run "mkdir -p ${WEBDIR}"
 do_copy $progdir/../srv/www ${WEBDIR}/../
 do_copy $progdir/../lib/systemd/system/webpy.service /lib/systemd/system/ 644
 run "systemctl enable webpy.service"
+run "systemctl enable systemd-networkd.service systemd-networkd-wait-online.service"
 run "systemctl daemon-reload"
 
 # change ownership for web databases to cowrie as we will run the


### PR DESCRIPTION
Enabling networkd and networkd-wait-online service to be able to use it with systemd and wait for networking to be ready