### PR TITLE
Corrected print function syntax.

### DIFF
--- a/bin/smtp.py
+++ b/bin/smtp.py
@@ -5,10 +5,10 @@ import asyncore
 
 class CustomSMTPServer(smtpd.SMTPServer):
     def process_message(self, peer, mailfrom, rcpttos, data):
-        print 'Receiving message from:', peer
-        print 'Message addressed from:', mailfrom
-        print 'Message addressed to  :', rcpttos
-        print 'Message length        :', len(data)
+        print ('Receiving message from:', peer)
+        print ('Message addressed from:', mailfrom)
+        print ('Message addressed to  :', rcpttos)
+        print ('Message length        :', len(data))
         return
 def mailserv(port):
     server = CustomSMTPServer(('', port), None)
@@ -20,5 +20,4 @@ if __name__ == '__main__':
     try:
         mailserv()
     except:
-        print "Requires basehttpserver response, match, and module."
-
+        print ("Requires basehttpserver response, match, and module.")

--- a/srv/www/bin/sigmatch.py
+++ b/srv/www/bin/sigmatch.py
@@ -39,9 +39,9 @@ def sigmatch(self, pattern, module):
                 response = c.execute(
                     """SELECT * FROM """ + str(db_ref[0]) + """ WHERE SigID=?""", [str(SigID[0])]).fetchall()
             except:
-                print 'Error detecting response DB.'
-                print SigID[0]
-                print db_ref[0]
+                print ('Error detecting response DB.')
+                print ('SigID[0]')
+                print ('db_ref[0]')
             if module == 'lfi':
                 for i in response:
                     if re.match(i[1], pattern) is not None:


### PR DESCRIPTION
Corrected print function syntax in bin/smtp.py from lines 8 to 11 & 23. Removed carriage returns. 

note for file: smtp.py, I will be checking the functionality of the file in the future. I have no executed the file for functionality check. 

Corrected print function syntax in srv/www/bin/sigmatch.py from 42 to 44.

Thank you. 