### PR TITLE
Bugfix: resolve invalid references

### DIFF
--- a/srv/dshield/DShield.py
+++ b/srv/dshield/DShield.py
@@ -157,7 +157,7 @@ class DshieldSubmit:
         return 2**32-(2**(32-mask))
 
     def readconfig(self, filename):
-        home = os.getenv("HOME")
+        home = os.getenv("HOME", "")
         if filename == '':
             if os.path.isfile(home+'/etc/dshield.ini'):
                 filename = home+'/etc/dshield.ini'

--- a/srv/dshield/fwlogparser.py
+++ b/srv/dshield/fwlogparser.py
@@ -116,7 +116,7 @@ if '-p' in args:  # overwrite log file
 if '-d' in args:  # debug mode
     debug = 1
 if '-c' in args:  # alternate config file
-    print("Alternate config file: %s" % s)
+    print("Alternate config file: %s" % args['-c'])
     config = args['-c']
 
 try:


### PR DESCRIPTION
### Fix Traceback in `/srv/dshield/fwlogparser.py`

Checking my syslog, I noticed a traceback in `fwlogparser.py`:

```
Mar 16 00:00:22 honeypot systemd[1]: Starting Rotate log files...
Mar 16 00:00:23 honeypot logrotate[19452]: Traceback (most recent call last):
Mar 16 00:00:23 honeypot logrotate[19452]:   File "/srv/dshield/fwlogparser.py", line 106, in <module>
Mar 16 00:00:23 honeypot logrotate[19452]:     d = DshieldSubmit('')
Mar 16 00:00:23 honeypot logrotate[19452]:   File "/srv/dshield/DShield.py", line 49, in __init__
Mar 16 00:00:23 honeypot logrotate[19452]:     self.readconfig(filename)
Mar 16 00:00:23 honeypot logrotate[19452]:   File "/srv/dshield/DShield.py", line 162, in readconfig
Mar 16 00:00:23 honeypot logrotate[19452]:     if os.path.isfile(home+'/etc/dshield.ini'):
Mar 16 00:00:23 honeypot logrotate[19452]: TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
Mar 16 00:00:23 honeypot logrotate[19452]: error: error running non-shared prerotate script for /var/log/dshield.log of '/var/log/dshield.log
Mar 16 00:00:23 honeypot logrotate[19452]: '
```

By providing a default value for `HOME`, the type error will no longer occur.

### Correct log reference when using an alt config

I have not experienced issues with this fix, but I noticed that `s` is never defined. I corrected the log message to use the value from `args['-c']`