### PR TITLE
Some updates in bin/status.sh, bin/install.sh README_openSUSE.md

### DIFF
--- a/README_openSUSE.md
+++ b/README_openSUSE.md
@@ -54,10 +54,8 @@ In order to use the installation script on the Raspberry Pi, you will need to fi
 
     *zypper in --no-recommends git*
     
-- make install directory and get GIT repository  
+- get GIT repository  
 
-    *mkdir install*  
-    *cd install*  
     <em>git clone <span>https</span>://github.com/DShield-ISC/dshield.git<em>  
     
 - run the installation script  

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -13,16 +13,22 @@
 ## CONFIG SECTION
 ###########################################################
 
-# version 2020/11/10 01
+# version 2020/11/13 01
 
-readonly myversion=80
+readonly myversion=81
 
 #
 # Major Changes (for details see Github):
 #
 #
+# - V81 (Freek)
+#   - fixes in status.sh when run in cron
+#   - removed folder install for openSUSE in README
+#   - added support for openSUSE in uninstall.sh
+#   - fixes for typos
+#
 # - V80 (Freek)
-#   - Consistent use of manualupdate, also saved in dhield.ini
+#   - Consistent use of manualupdate, also saved in dshield.ini
 #   - value of progdir saved in dshield.ini
 #
 # - V79 (Johannes)
@@ -45,7 +51,7 @@ readonly myversion=80
 #   - some cleanup
 
 # - V75 (Johannes)
-#   - fixes for Pythong3 (web.py)
+#   - fixes for Python3 (web.py)
 #   - added a piid
 #   - updated cowrie
 
@@ -1407,7 +1413,7 @@ if [ "$ID" != "opensuse" ]; then
     run 'systemctl enable iptables.service'
   fi
 else # openSUSE stuff
-  dlog "Copying /etc/network/iptables-init, /etc/network/iptables-stop, /usr/lib/systemd/system/dshiedfirewall*.service"
+  dlog "Copying /etc/network/iptables-init, /etc/network/iptables-stop, /usr/lib/systemd/system/dshieldfirewall*.service"
   do_copy $progdir/../etc/network/iptables-init /etc/network/iptables-init 600
   do_copy $progdir/../etc/network/iptables-stop /etc/network/iptables-stop 600
   do_copy $progdir/../lib/systemd/system/dshieldfirewall_init.service /usr/lib/systemd/system/dshieldfirewall_init.service 644
@@ -1927,6 +1933,23 @@ do_copy $progdir/../etc/logrotate.d/dshield /etc/logrotate.d 644
 [ "$ID" = "opensuse" ] && sed -e 's/\/usr\/lib.*$/systemctl reload rsyslog/' -i /etc/logrotate.d/dshield
 if [ -f "/etc/cron.daily/logrotate" ]; then
   run "mv /etc/cron.daily/logrotate /etc/cron.hourly"
+fi
+
+###########################################################
+## POSTINSTALL OPTION
+###########################################################
+
+if [ -f /root/bin/postinstall.sh ]; then
+  run "/root/bin/postinstall.sh"
+else
+  outlog
+  outlog
+  outlog "POSTINSTALL OPTION"
+  outlog
+  outlog "In case you need to do something extra after an installation, especially when you do an automatic"
+  outlog "update, in which case you may loose changes made after the initial installation."
+  outlog "For this situation you can have a post-installation script in /root/bin/postinstall.sh, which"
+  outlog "will be called at the end of processing the install.sh script, also called in the automatic update."
 fi
 
 ###########################################################

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -15,11 +15,15 @@
 
 # version 2020/11/10 01
 
-readonly myversion=79
+readonly myversion=80
 
 #
 # Major Changes (for details see Github):
 #
+#
+# - V80 (Freek)
+#   - Consistent use of manualupdate, also saved in dhield.ini
+#   - value of progdir saved in dshield.ini
 #
 # - V79 (Johannes)
 #   - minor fixes to properly report version during status check and update check
@@ -1471,10 +1475,12 @@ if [ "$MANUPDATES" == "" ]; then
   MANUPDATES=0
 fi
 
-if [ "$MANUPDATES" -eq "0" ]; then
-  dlog "automatic updates OK, configuring"
-  run 'touch ${DSHIELDDIR}/auto-update-ok'
-fi
+# Manual updates now consistent in dshield.ini; parameter manualupdates
+# 0 is auto-update, 1 is manual update
+#if [ "$MANUPDATES" -eq "0" ]; then
+#  dlog "automatic updates OK, configuring"
+#  run 'touch ${DSHIELDDIR}/auto-update-ok'
+#fi
 
 #
 # "random" offset for cron job so not everybody is reporting at once
@@ -1547,6 +1553,8 @@ nohoneyips=$(quotespace $nohoneyips)
 run 'echo "nohoneyips=$nohoneyips" >> /etc/dshield.ini'
 nohoneyports=$(quotespace $nohoneyports)
 run 'echo "nohoneports=$nohoneyports" >> /etc/dshield.ini'
+run 'echo "progdir=$progdir" >> /etc/dshield.ini'
+run 'echo "manualupdates=$MANUPDATES" >> /etc/dshield.ini'
 dlog "new /etc/dshield.ini follows"
 drun 'cat /etc/dshield.ini'
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -26,6 +26,7 @@ readonly myversion=81
 #   - removed folder install for openSUSE in README
 #   - added support for openSUSE in uninstall.sh
 #   - fixes for typos
+#   - added post-install option
 #
 # - V80 (Freek)
 #   - Consistent use of manualupdate, also saved in dshield.ini

--- a/bin/status.sh
+++ b/bin/status.sh
@@ -6,9 +6,15 @@
 #
 ####
 
-RED=$(tput setaf 1)
-GREEN=$(tput setaf 2)
-NC=$(tput sgr0)
+if [ "$TERM" != "" ]; then
+   RED=$(tput setaf 1)
+   GREEN=$(tput setaf 2)
+   NC=$(tput sgr0)
+else
+   RED=
+   GREEN=
+   NC=
+fi
 
 email=''
 apikey=''
@@ -188,7 +194,7 @@ checkfile "/srv/cowrie/cowrie.cfg"
 TESTS['cowriecfg']=$?
 checkfile "/etc/rsyslog.d/dshield.conf"
 TESTS['dshieldconf']=$?
-if iptables -L -n -t nat | grep -q DSHIELDINPUT; then
+if /usr/sbin/iptables -L -n -t nat | grep -q DSHIELDINPUT; then
   echo "${GREEN}OK${NC}: firewall rules"
   TESTS['fw']=1
 else

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -7,20 +7,37 @@ if [ ! "$userid" = "0" ]; then
    echo ${LINE}
    exit 9
 fi
+if [ ! -f /etc/os-release ]; then
+  echo "I can not find the /etc/os-release file. You are likely not running a supported operating system"
+  echo "please email info@dshield.org for help."
+  exit 9
+fi
+. /etc/os-release
 systemctl stop cowrie
 systemctl stop webpy
 for b in `ps -ef | grep '^cowrie' | awk '{print $2}'`; do kill -9 $b; done
 rm -rf /srv/*
 rm -rf /etc/dshield.ini.*
+rm -rf /etc/dshield.sslca.*
 mv /etc/dshield.ini /etc/dshield.ini.backup
+mv /etc/dshield.sslca /etc/dshield.sslca.backup
 rm -rf /etc/cron.d/dshield
 rm -rf /etc/rsyslog.d/dshield.conf
 rm -rf /var/run/dshield
 rm -rf /lib/systemd/system/cowrie.service
 rm -rf /lib/systemd/system/webpy.service
-rm -rf /etc/network/iptables
-systemctl enable ufw
-deluser cowrie
+rm -rf /etc/network/iptables*
+if [ "${ID:0:8}" != "opensuse" ]; then
+   systemctl enable ufw
+   deluser cowrie
+else
+   systemctl stop dshieldfirewall.service
+   systemctl stop dshieldfirewall_init.service
+   systemctl disable dshieldfirewall.service
+   systemctl disable dshieldfirewall_init.service
+   rm /usr/lib/systemd/system/dshieldfirewall*.service
+   userdel -f -r cowrie
+fi
 echo "Done. Please reboot. The SSH daemon is still listening on port 12222"
 
 

--- a/etc/cron.hourly/dshield
+++ b/etc/cron.hourly/dshield
@@ -13,13 +13,14 @@ if [ ! "$userid" = "0" ]; then
    exit
 fi
 
+version=0.0
+source <(grep = /etc/dshield.ini | sed 's/ *= */=/g')
+
 # check if automatic updates are allowed
-if [ ! -f /srv/dshield/auto-update-ok ] ; then
+if [ $manualupdates -eq 1 ] ; then
    exit
 fi
 
-version=0.0
-source <(grep = /etc/dshield.ini | sed 's/ *= */=/g')
 nonce=`openssl rand -hex 10`
 hash=`echo -n $email:$apikey | openssl dgst -hmac $nonce -sha512 -hex | cut -f2 -d'=' | tr -d ' '`
 # TODO: urlencode($user)


### PR DESCRIPTION
Test for update showed errors in cron. Improved script to avoid these errors.
Updated uninstall.sh to support openSUSE.
Updated status.sh
Repaired some typos.
Added an option to call a post-install script. Especially for automatic updates in case the user added some changes in the code to suit his/her needs. The script should be in /root/bin/postinstall.sh.