### PR TITLE
Fixes in update.sh and fwlogparser.py; auto update also for openSUSE

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -21,6 +21,12 @@ readonly myversion=81
 # Major Changes (for details see Github):
 #
 #
+# - V82 (Freek)
+#   - fix in update.sh to call ./install.sh in proper folder
+#   - fix in fwlogparser.py to save lastcount in persistent folder
+#     /var/run/ may not survive a reboot; /var/tmp used instead
+#   - auto update may be used on openSUSE also
+#
 # - V81 (Freek)
 #   - fixes in status.sh when run in cron
 #   - removed folder install for openSUSE in README
@@ -655,11 +661,6 @@ if [ "$INTERACTIVE" == 1 ]; then
     MANUPDATES=1
   else
     MANUPDATES=0
-  fi
-
-  if [ "$ID" == "opensuse" ]; then
-    MANUPDATES=1
-    dlog "Only manual updates on openSUSE"
   fi
 
   dlog "MANUPDATES: ${MANUPDATES}"

--- a/bin/status.sh
+++ b/bin/status.sh
@@ -152,8 +152,8 @@ echo $status | sed 's/.*<lastreport>//' | sed 's/<\/lastreport>.*//'
 echo "
 ###### Are the submit scripts running?
 "
-if [ -f /var/run/dshield/lastfwlog ]; then
-  lastlog=$(cat /var/run/dshield/lastfwlog)
+if [ -f /var/tmp/dshield/lastfwlog ]; then
+  lastlog=$(cat /var/tmp/dshield/lastfwlog)
   echo -n "Last Firewall Log Processed: "
   date +"%F %T" -d @$lastlog
   TESTS['lastfwlog']=1
@@ -162,8 +162,8 @@ else
   TESTS['lastfwlog']=0
 fi
 
-if [ -f /var/run/dshield/skipvalue ]; then
-  skip=$(cat /var/run/dshield/skipvalue)
+if [ -f /var/tmp/dshield/skipvalue ]; then
+  skip=$(cat /var/tmp/dshield/skipvalue)
   if [ "$skip" -eq "1" ]; then
     echo "${GREEN}All Logs are processed. You are not sending too many logs${NC}"
   fi

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -60,6 +60,7 @@ echo Current Version: $newversion
 
 if [ "$newversion" -gt "$version" ]; then
     echo "Update"
+    cd $progdir
     git checkout main
     git pull
     ./install.sh --update

--- a/etc/openssl.cnf
+++ b/etc/openssl.cnf
@@ -3,7 +3,7 @@ default_ca	= CA_default		# The default ca section
 
 [ CA_default ]
 
-dir = /home/pi/install/dshield/bin//../etc/CA
+dir = /home/pi/dshield/bin//../etc/CA
 certs		= $dir/certs		# Where the issued certs are kept
 crl_dir = $dir/crls
 database	= $dir/index.txt	# database index file.

--- a/srv/dshield/fwlogparser.py
+++ b/srv/dshield/fwlogparser.py
@@ -94,6 +94,7 @@ def checklock(lockfile):
 # define paramters
 logfile = "/var/log/dshield.log"
 piddir="/var/run/dshield/"
+lastdir="/var/tmp/dshield/"
 config = "/etc/dshield.ini"
 startdate = 0
 now = datetime.utcnow()
@@ -124,9 +125,14 @@ try:
 except:
     os.mkdir(piddir)
 
+try:
+    os.stat(lastdir)
+except:
+    os.mkdir(lastdir)
+
 pidfile = piddir+"fwparser.pid"
-lastcount = piddir+"lastfwlog"
-skipvalue = piddir+"skipvalue"
+lastcount = lastdir+"lastfwlog"
+skipvalue = lastdir+"skipvalue"
     
 if os.path.isfile(logfile) is None:
     sys.exit('Can not find logfile %s ' % logfile)


### PR DESCRIPTION
Call of ./install.sh in update.sh requires a cd $progdir
fwlogparser.py saves lastcount in /var/run/dshield/ which may not survive a reboot, and does not in my case; moved to /var/tmp/dshield/ which should survive reboots.
For openSUSE auto update is now also a choice.
Version now 82.