### PR TITLE
Adding simple helper scripts

### DIFF
--- a/bin/interesting.sh
+++ b/bin/interesting.sh
@@ -1,0 +1,17 @@
+#! /bin/sh
+#
+#
+#interesting
+#
+#    #this command shows a preview of the latest downloaded files (note the file names as sha256 hashes,inode values, and timestamps) as well as the replay logs from attacks on the ssh and telnet fake-services, whcih were allowed by cowrie to be successful (replay logs):
+#    #note also that the replay logs are grepable (UML compatible, user-mode-linux) even though they are not completely human-readable
+#
+#
+#    #mroe cowrie files of interest are listed at https://github.com/cowrie/cowrie
+#
+#
+#    interesting files... (newest 10 of each)
+ls -lahit /srv/cowrie/var/lib/cowrie/tty | head -n 15
+echo "\n \n"; echo " ^above are the latest 10 recorded shell replay files......^    _below are the latest 10 files downloaded into the honeypot (probablly malware), names a
+re the files' sha256 sums"; echo "\n"
+ls -lahit /srv/cowrie/var/lib/cowrie/downloads | head -n 15

--- a/bin/monitor.sh
+++ b/bin/monitor.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+#
+#
+#    #This command updates every 2 seconds and diplays including the inode entry, sorted by time, downloaded files from the fake cowrie filesystem, for example that were downloaded over connections masqueraded as "successful" on the ssh or telnet fake-services (by default the 15 latest)
+#    #Then it displays a preview of the firewall log file (sent to the DShield chains in iptables)
+#
+#    other files which may be of similar interest to you include the logs at /srv/cowrie/var/log/cowrie and the terminal "replay logs" themselves at /srv/cowrie/var/lib/cowrie/tty
+#
+#    #further watch options that are usful, like change highlighting -e or -n [time spec] see 'man watch'
+#
+#    #command:
+watch  'ls -lahit /srv/cowrie/var/lib/cowrie/downloads | head -n 17; echo "\n"; tail -n 10  /var/log/dshield.log'

--- a/bin/replay.sh
+++ b/bin/replay.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+#
+#This 'replay' script is just a shortcut essentially to useing the built-in playlog.py (python script) from cowrie
+#
+#    usage "$HOME/install/dshield/bin/replay.sh [file name of reply file]"
+#    ...it is not necessary to supply the full path of the replay file name
+#
+#
+#TODO:  check first for python versions
+#
+#TODO: add content for doing --usage / help also as error correction
+#
+#    replay:
+python3 /srv/cowrie/bin/playlog /srv/cowrie/var/lib/cowrie/tty/"$1"


### PR DESCRIPTION
These may be mentioned in an upcoming diary:
-interesting.sh
-replay.sh
-monitor.sh

May need also to put DShield's /bin directly in the path or add these (and the other scripts) in a separate directory etc.