### PR TITLE
Added support for raspios armhf and arm64 (bullseye) and a few other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sudo apt-get -y install git
 ```
 git clone https://github.com/DShield-ISC/dshield.git
 ```
-- run the installation script
+- run the installation script, in case you do have an earlier system, copy the files `/etc/dshield.ini` and `/etc/dshield.sslca` from that system to `/etc`; you will be able to reuse the data entered for that system.
 ```
 cd dshield/bin
 sudo ./install.sh

--- a/README_cron.md
+++ b/README_cron.md
@@ -7,6 +7,7 @@ During the install of the honeypot, a ```/etc/cron.d/dshield``` is created with 
 ### weblog submit
 
 The weblogsubmit.py script is run twice an hour (the times are randomly set during install, but 30 minutes from each other). This script will read logs from the sqlite database (/srv/www/DB/webserver.sqlite) and submit them to DShield via HTTPs
+Also the webpy.sh script is run at the same time, it checks the status of the webpy service. If certain condition are found, this service will be restarted. It may be enough to exclude the reboot mentioned lower in this text. It needs lsof to be installed, which is done for systems using apt and zypper.
 
 ### firewall logs parser
 
@@ -18,5 +19,6 @@ If the user selected automatic updates, the update.sh script runs once a day at 
 
 ### reboot
 
-The honeypot reboots once a day (again: at a random time set during install). This is a hopefully temporary fix to solve some stability issues in web.py the hard way
+The honeypot reboots once a day (again: at a random time set during install). This is a hopefully temporary fix to solve some stability issues in web.py the hard way.
+See above, try to comment this out and watch the status of the systemd webpy service.
 

--- a/bin/status.sh
+++ b/bin/status.sh
@@ -199,12 +199,16 @@ TESTS['cowriecfg']=$?
 checkfile "/etc/rsyslog.d/dshield.conf"
 TESTS['dshieldconf']=$?
 IPTABLES=/usr/sbin/iptables
+NFT=/usr/sbin/nft
 if [ -f /sbin/iptables ]; then
     IPTABLES=/sbin/iptables
 fi
 
-if $IPTABLES -L -n -t nat | grep -q DSHIELDINPUT; then
-  echo "${GREEN}OK${NC}: firewall rules"
+if [ -f $IPTABLES ] && [ $IPTABLES -L -n -t nat | grep -q DSHIELDINPUT ] ; then
+  echo "${GREEN}OK${NC}: ip-firewall rules"
+  TESTS['fw']=1
+elif $NFT list ruleset | grep -q DSHIELDINPUT; then
+  echo "${GREEN}OK${NC}: nf-firewall rules"
   TESTS['fw']=1
 else
   echo "${RED}MISSING${NC}: firewall rules"

--- a/srv/dshield/webpy.sh
+++ b/srv/dshield/webpy.sh
@@ -2,4 +2,18 @@
 # check webpy errors
 lastline=$(journalctl -e -u webpy | tail -1)
 lastline=${lastline#*]: }
-[ "${lastline:0:10}" = "ValueError" -o "${lastline:0:5}" = "error" ] && systemctl restart webpy && echo webpy restarted
+if [ "${lastline:0:10}" = "ValueError" ] ; then
+  systemctl restart webpy.service
+  # echo "webpy restarted"
+  exit 0
+elif [ "${lastline:0:5}" = "error" ] ; then
+  systemctl restart webpy.service
+  # echo "webpy restarted"
+  exit 0
+elif [ "${lastline:8:16}" = "OperationalError" ] ; then
+  systemctl restart webpy.service
+  # echo "webpy restarted"
+  exit 0
+fi
+lsof -p $(pidof python3) | grep 5u | grep -q ESTABLISHED
+[ $? -eq 0 ] && systemctl restart webpy && echo "webpy restarted; 5u ESTAB "


### PR DESCRIPTION
I tested the newest Raspberry Pi OSes, both for armhf and arm64 and adapted the install.sh script to support these OSes. It looks as if they do not have standard support for iptables, so it came handy to use nftables for these systems.
I also use a script /srv/dshield/webpy.sh to monitor the webpy service. With this script I could disable the daily reboot -did not remove or commented it - and I did not have quite some time a stalled webpy service. It needs lsof to be installed, which I added for the apt systems, not for the amzn systems. The reboot often resulted is a system that was hanging in the boot process.