### PR TITLE
Removed unnecessary mv commands for cowrie

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1840,11 +1840,9 @@ fi
 dlog "moving extracted cowrie to ${COWRIEDIR}"
 if [ -d $TMPDIR/cowrie ]; then
   run "mv $TMPDIR/cowrie ${COWRIEDIR}"
-  run "mv ${COWRIEDIR}/cowrie ${COWRIEDIR}/cowrie"
 else
     if [ -d $TMPDIR/cowrie-master ]; then
 	run "mv $TMPDIR/cowrie-master ${COWRIEDIR}"
-	run "mv ${COWRIEDIR}/cowrie-master ${COWRIEDIR}/cowrie"
     else
 	outlog "$TMPDIR/cowrie / cowrie-master not found"
 	exit 9


### PR DESCRIPTION
I introduced a wrong mv command to copy cowrie from temp to its proper position, which is unnecessary.