### PR TITLE
Removes with statement that's breaking the workflow

### DIFF
--- a/.github/workflows/poetry-to-legacy.yml
+++ b/.github/workflows/poetry-to-legacy.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          path: main
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
The yaml syntax fix in the commit 7dfd563 broke the workflow that appeared to be working *because* the syntax was incorrect. This pull request removes the with statement entirely which unblocks the workflow.