### PR TITLE
Update install.sh and settings.py

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2004,6 +2004,10 @@ find /etc/rc?.d -name '*cowrie*' -delete
 run 'systemctl daemon-reload'
 run 'systemctl enable cowrie.service'
 
+dlog 'deactivate cowrie venv'
+run 'deactivate'
+
+
 ###########################################################
 ## Installation of isc-agent
 ###########################################################
@@ -2011,23 +2015,33 @@ run 'systemctl enable cowrie.service'
 outlog "Installing ISC-Agent"
 dlog "installing ISC-Agent"
 
-run "mkdir -p ${ISC_AGENT_DIR}"
+# support for ubuntu server 22.04.2 LTS
+dlog "(re)installing python attrs package"
+run "pip3 install --ignore-installed attrs"
 
+run "mkdir -p ${ISC_AGENT_DIR}"
 do_copy $progdir/../srv/isc-agent ${ISC_AGENT_DIR}/../
 do_copy $progdir/../lib/systemd/system/isc-agent.service ${systemdpref}/lib/systemd/system/ 644
 run "chmod +x /srv/isc-agent/bin/isc-agent"
 run "mkdir -m 0700 /srv/isc-agent/run"
-run "deactivate"
+
+dlog "activate isc-agent venv"
+run "source /srv/isc-agent/.venv/bin/activate"
+
 OLDPWD=$PWD
 cd ${ISC_AGENT_DIR}
 run "pip3 install --upgrade pip"
 run "pip3 install pipenv"
+run "pip3 install --ignore-installed -r requirements.txt --prefix /srv/isc-agent/.venv"
 run "pipenv lock"
 run "PIPENV_IGNORE_VIRTUALENVS=1 PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy"
 run "systemctl daemon-reload"
 run "systemctl enable isc-agent.service"
 [ "$ID" != "opensuse" ] && run "systemctl enable systemd-networkd.service systemd-networkd-wait-online.service"
 cd $OLDPWD
+
+dlog "deactivate isc-agent venv"
+run "deactivate"
 
 ###########################################################
 ## Copying further system files
@@ -2191,6 +2205,15 @@ clear
 if [ ${GENCERT} -eq 1 ]; then
   dlog "generating new CERTs using ./makecert.sh"
   ./makecert.sh
+
+  dlog "moving certs to /srv/isc-agent"
+  run "mv $SCRIPTDIR/dshield/etc/CA/keys/honeypot.key /srv/isc-agent/honeypot.key"
+  run "mv $SCRIPTDIR/dshield/etc/CA/certs/honeypot.crt /srv/isc-agent/honeypot.crt"
+
+  dlog "updating /etc/dshield.ini"
+  run 'echo "tlskey=/srv/isc-agent/honeypot.key" >> /etc/dshield.ini'
+  run 'echo "tlscert=/srv/isc-agent/honeypot.crt" >> /etc/dshield.ini'
+
 fi
 
 #

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2029,9 +2029,9 @@ OLDPWD=$PWD
 cd ${ISC_AGENT_DIR}
 run "pip3 install --upgrade pip"
 run "pip3 install pipenv"
-run "pip3 install --ignore-installed -r requirements.txt --prefix /srv/isc-agent/.venv"
 run "pipenv lock"
 run "PIPENV_IGNORE_VIRTUALENVS=1 PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy"
+run "pip3 install --ignore-installed -r requirements.txt --prefix /srv/isc-agent/.venv"
 run "systemctl daemon-reload"
 run "systemctl enable isc-agent.service"
 [ "$ID" != "opensuse" ] && run "systemctl enable systemd-networkd.service systemd-networkd-wait-online.service"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2025,9 +2025,6 @@ do_copy $progdir/../lib/systemd/system/isc-agent.service ${systemdpref}/lib/syst
 run "chmod +x /srv/isc-agent/bin/isc-agent"
 run "mkdir -m 0700 /srv/isc-agent/run"
 
-dlog "activate isc-agent venv"
-run "source /srv/isc-agent/.venv/bin/activate"
-
 OLDPWD=$PWD
 cd ${ISC_AGENT_DIR}
 run "pip3 install --upgrade pip"
@@ -2039,9 +2036,6 @@ run "systemctl daemon-reload"
 run "systemctl enable isc-agent.service"
 [ "$ID" != "opensuse" ] && run "systemctl enable systemd-networkd.service systemd-networkd-wait-online.service"
 cd $OLDPWD
-
-dlog "deactivate isc-agent venv"
-run "deactivate"
 
 ###########################################################
 ## Copying further system files

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -791,11 +791,8 @@ if [ "$FAST" == "0" ]; then
     fi
   fi
 
-  if [ "$ID" != "opensuse" ]; then
-    drun 'pip3 list --format=legacy'
-  else
-    drun 'pip3 list --format=columns'
-  fi
+  drun 'pip3 list --format=columns'
+  
 else
   outlog "Skipping PIP check in FAST mode"
 fi
@@ -1904,7 +1901,7 @@ OLDDIR=$(pwd)
 
 
 cd ${COWRIEDIR}
-dlog "installing global rependencies from ${SCRIPTDIR}/requirements.txt"
+dlog "installing global dependencies from ${SCRIPTDIR}/requirements.txt"
 run 'pip3 install --upgrade pip'
 run "pip3 install -r ${SCRIPTDIR}/requirements.txt"
 dlog "setting up virtual environment"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2207,8 +2207,8 @@ if [ ${GENCERT} -eq 1 ]; then
   ./makecert.sh
 
   dlog "moving certs to /srv/isc-agent"
-  run "mv $SCRIPTDIR/dshield/etc/CA/keys/honeypot.key /srv/isc-agent/honeypot.key"
-  run "mv $SCRIPTDIR/dshield/etc/CA/certs/honeypot.crt /srv/isc-agent/honeypot.crt"
+  run "mv $SCRIPTDIR/../etc/CA/keys/honeypot.key /srv/isc-agent/honeypot.key"
+  run "mv $SCRIPTDIR/../etc/CA/certs/honeypot.crt /srv/isc-agent/honeypot.crt"
 
   dlog "updating /etc/dshield.ini"
   run 'echo "tlskey=/srv/isc-agent/honeypot.key" >> /etc/dshield.ini'

--- a/srv/isc-agent/settings.py
+++ b/srv/isc-agent/settings.py
@@ -91,8 +91,8 @@ DATABASE_SESSION = Session(DATABASE_ENGINE)
 
 # SSL certification key and certificate
 
-PRIVATE_KEY = config.get('isc-agent', 'tlskey', fallback='/srv/isc-agent/honeypot.key')
-CERT_KEY = config.get('isc-agent', 'tlscert', fallback='/srv/isc-agent/honeypot.crt')
+PRIVATE_KEY = config.get('iscagent', 'tlskey', fallback='/srv/isc-agent/honeypot.key')
+CERT_KEY = config.get('iscagent', 'tlscert', fallback='/srv/isc-agent/honeypot.crt')
 
 # PLUGINS
 # Read from /etc/dshield.ini file


### PR DESCRIPTION
Updating install.sh:
- "pip3 list --format=legacy" no longer works, changed to column format
- fixed a typo "rependencies"
- deactivate the cowrie venv when cowrie configuration is complete
- install isc-agent dependences directly in the isc-agent venv lib
- move honeypot key and crt files to /srv/isc-agent and write their location to /etc/dshield.ini for settings.py

Updating settings.py:
- fixed honeypot key and crt variables to be compatible with /etc/dshield.ini ([iscagent] instead of [isc-agent])