### PR TITLE
Fix plugins' main.py to update isc-agent.sqlite

### DIFF
--- a/srv/isc-agent/plugins/tcp/http/main.py
+++ b/srv/isc-agent/plugins/tcp/http/main.py
@@ -102,6 +102,8 @@ def log_request(request_attributes: Dict, signature_id: Optional[int] = None, re
 def submit_logs():
     # Submit logs
     request_logs = settings.DATABASE_SESSION.query(RequestLog).all()
+    settings.DATABASE_SESSION.add_all(request_logs) # adds logs to current session
+    settings.DATABASE_SESSION.commit() # commits the change to the db (/srv/db/isc-agent.sqlite)
     logger.debug(request_logs)
     if request_logs:
         auth = get_auth()


### PR DESCRIPTION
NOTE: Recommend testing before committing to ensure formatting is correct and this exhibits the intended behavior. While this change does write to the db file, if the isc-agent is restarted it appears to wipe the local db (/srv/db/isc-agent.sqlite).
- change commits logs to the sqlite file so user can query