### PR TITLE
Bug/access-log-parser-fixes

### DIFF
--- a/srv/dshield/access_log_parser.py
+++ b/srv/dshield/access_log_parser.py
@@ -30,11 +30,11 @@ f.close()
 parseline = re.compile('^(\S+)\s(\S+) \S+ \S+ \[([^\]]+)\]\s"([^"]+)" ([0-9]{3}) [0-9]+ "[^"]+" "([^"]+)"$')
 isip = re.compile('^([0-9\.]+)')
 logs = []
-starttime = None
+starttime = 0
 try:
     with open("lastweblogtime.txt") as file:
-        starttime = file.read()
-        starttime = int(starttime.strip())
+        starttime = file.read().strip()
+        starttime = int(starttime)
 except:
     pass
 if not starttime:

--- a/srv/isc-agent/pyproject.toml
+++ b/srv/isc-agent/pyproject.toml
@@ -14,6 +14,7 @@ sqlalchemy = "~=1.4.31"
 cryptography = "==3.4.6"
 twisted = {extras = ["all_non_platform", "http2"], version = "~=22.10.0"}
 defusedxml = "~=0.7.1"
+dateutil="*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
@@ -25,6 +26,7 @@ coverage = "*"
 factory-boy = "*"
 markdown = "*"
 tox = "*"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/srv/isc-agent/pyproject.toml
+++ b/srv/isc-agent/pyproject.toml
@@ -14,7 +14,7 @@ sqlalchemy = "~=1.4.31"
 cryptography = "==3.4.6"
 twisted = {extras = ["all_non_platform", "http2"], version = "~=22.10.0"}
 defusedxml = "~=0.7.1"
-dateutil="*"
+python-dateutil="*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
Fixes an error of a method call on a NoneType object and adds python-dateutil to the dependency tree -- as it's currently called in the code but not in requirements.