### PR TITLE
Fixes imports and poetry to legacy action

### DIFF
--- a/.github/workflows/poetry-to-legacy.yml
+++ b/.github/workflows/poetry-to-legacy.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd srv/isc-agent
           poetry export -f requirements.txt -o requirements.txt --without-hashes
-          grep -v 'Windows' requirements.txt | cut -f1 -d '='  > ../../bin/requirements.txt
+          grep -v 'Windows' requirements.txt | cut -f1 -d '=' | sed 's/all-non-platform/all_non_platform/'  > ../../bin/requirements.txt
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:

--- a/srv/isc-agent/pyproject.toml
+++ b/srv/isc-agent/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 python = "^3.7.1"
 jinja2 = "~=3.0.3"
-pydantic = {extras = ["dotenv", "email"], version = "~=1.9.0"}
+pydantic = {extras = ["email"], version = "~=1.9.0"}
 requests = "~=2.27.1"
 sqlalchemy = "~=1.4.31"
 cryptography = "==3.4.6"


### PR DESCRIPTION
Removes the no longer existing option of 'dotenv' from pydantic and fixes the 'all_non_platform' option of twisted.