### PR TITLE
Fix GitHub action versions

### DIFF
--- a/.github/workflows/isc-agent-action.yml
+++ b/.github/workflows/isc-agent-action.yml
@@ -9,7 +9,7 @@ jobs:
     name: Code Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Code scan
       run: make ops-scan
       working-directory: ./srv/isc-agent

--- a/.github/workflows/poetry-to-legacy.yml
+++ b/.github/workflows/poetry-to-legacy.yml
@@ -22,7 +22,7 @@ jobs:
           poetry export -f requirements.txt -o requirements.txt --without-hashes
           grep -v 'Windows' requirements.txt | cut -f1 -d '=' | sed 's/all-non-platform/all_non_platform/'  > ../../bin/requirements.txt
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           author_name: "GitHub Action"
           author_email: "action@github.com"


### PR DESCRIPTION
We were using some outdated actions versions that were raising errors as they were utilizing outdated libraries and runtimes. This CR updates those versions.