### PR TITLE
This PR fixes JSON format, stunnel.pid location, noisy http/socket exception logs

### DIFF
--- a/srv/web/isc_agent/stunnel_manager.py
+++ b/srv/web/isc_agent/stunnel_manager.py
@@ -124,7 +124,7 @@ class StunnelManager:
             for port in self.https_ports:
                 #f.write("setuid = nobody\n")
                 #f.write("setgid = nogroup\n")
-                #f.write("pid = /var/run/stunnel.pid\n")
+                f.write("pid = /srv/webhpot/run/stunnel.pid\n")
                 f.write("foreground = yes\n")
                 f.write(f"output = {Path().cwd().joinpath('stunnel.log')}\n")
                 f.write("; HTTPS Proxy (With SSL/TLS Encryption)\n")


### PR DESCRIPTION
- One of the commits changes the local json responses to double quote (proper json) instead of python dictionaries
- One of the commits logs the majority of common socket and http connection requests with one line instead of large tracebacks.  This may be further tuned later and all logs eliminated by removing the "else:" block
- One of the commits changes the default location for the stunnel.pid file so that it can be run as a non-root user.