### PR TITLE
Give local logging a default value

### DIFF
--- a/srv/web/isc_agent/__main__.py
+++ b/srv/web/isc_agent/__main__.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
     sh.setLevel(level=numeric_level)
 
     #Set log level to debug if its in the config
-    record_local_responses = config.get('plugin:tcp:http','enable_local_logs') == 'true'   #Its lowercase.
+    record_local_responses = config.get('plugin:tcp:http','enable_local_logs',fallback='false') == 'true'   #Its lowercase.
 
     #Set local logfile path 
     local_response_path = config.get('plugin:tcp:http','local_logs_file', fallback='/srv/log/isc-agent.out')


### PR DESCRIPTION
If "enable_local_logs" is not defined in the dshield.ini an error is generated.   This will give it a default value of "false" if it is not defined in the .ini so that no error is produced if the setting is missing.

This will resolve issue #299 

