### PR TITLE
Fix {date} processing in local log file name

### DIFF
--- a/srv/web/isc_agent/__main__.py
+++ b/srv/web/isc_agent/__main__.py
@@ -195,9 +195,11 @@ class HoneypotRequestHandler(BaseHTTPRequestHandler):
         if record_local_responses:
             try:
                 # if the file name "local_response_path" includes the string {date} then replace it with the current date
-                if "{date}" in local_response_path:
-                    local_response_path = local_response_path.replace("{date}", datetime.datetime.now().strftime("%Y-%m-%d"))
-                fh = open(local_response_path, "a")
+                #"local_response_path" is a global variable and can only be read not assigned so a local variable log_path is used
+                log_path = local_response_path
+                if "{date}" in log_path:
+                    log_path = log_path.replace("{date}", datetime.datetime.now().strftime("%Y-%m-%d"))
+                fh = open(log_path, "a")
                 fh.write(f"{json.dumps(log_data)}\n")
                 fh.close()
             except Exception as e:


### PR DESCRIPTION
This will fix issue #308 

The problem is that "local_response_path" is a global variable.   Python considers any variable that is either passed as an argument or defined on the left hand side of an equals sign to be a local variable.   So when this code is added:

```
                if "{date}" in local_response_path:
                    local_response_path = local_response_path.replace("{date}", datetime.datetime.now().strftime("%Y-%m-%d"))
```

The if statment says that "local_response_path" does not exist.  The fact that "local_response_path" on the next line is on the left hand side of an equals sign means that it is now a local variable.   Alternatively this could be fixed by adding "global local_response_path" to the top of the function, but I think this is better.

Note that if an exception occurs and "{date}" is part of the path then exception will not resolve {date} and just print "{date}" in the error message.  IMO that's fine.