### PR TITLE
Update Ubuntu.md for no password sudo prompts

### DIFF
--- a/docs/install-instructions/Ubuntu.md
+++ b/docs/install-instructions/Ubuntu.md
@@ -13,6 +13,9 @@ Select the appropriate Ubuntu Server 24.04 package from your provider. You won't
 ```
 sudo adduser --disabled-password --gecos "DShield Honeypot" dshield
 sudo adduser dshield sudo
+echo 'dshield ALL=(ALL:ALL) NOPASSWD: ALL' | sudo tee /etc/sudoers.d/dshield sudo
+chmod 440 /etc/sudoers.d/dshield
+sudo visudo -cf /etc/sudoers.d/dshield
 ```
 
 If you installed the "minimum server": Make sure to install the editor of your choice. (for example, "sudo apt install emacs-nox").


### PR DESCRIPTION
Some platforms, like Digital Ocean, may require a password prompt for sudo with a newly created user account, which currently creates issues during the install.  Adding the user, even with "--disabled-password' still generated a password entry prompt on sudo use.